### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Connor4898's ModPE Scripts! (Abandoned)
+# Connor4898's ModPE Scripts! (Abandoned)
 
 ```
 This program is free software: you can redistribute it and/or modify
@@ -12,11 +12,11 @@ I created a GitHub Repo for my ModPE Scripts, so everyone can easily see the cod
 
 Please don't copy or claim these scripts as your own. You can release your own versions of these scripts, but give me credit and post a link to my forum too.
 
-###[Connor4898's Forum Topic] (http://www.minecraftforum.net/topic/1931167-)
+### [Connor4898's Forum Topic] (http://www.minecraftforum.net/topic/1931167-)
 
-###[ModPE Functions Wiki] (https://github.com/Connor4898/ModPE-Scripts/wiki/ModPE-Scripts-Functions-List)
+### [ModPE Functions Wiki] (https://github.com/Connor4898/ModPE-Scripts/wiki/ModPE-Scripts-Functions-List)
 
-###[WhyToFu's Forum] (http://www.minecraftforum.net/topic/1927514-)
+### [WhyToFu's Forum] (http://www.minecraftforum.net/topic/1927514-)
 
 Many thanks,
 

--- a/SPC/README.md
+++ b/SPC/README.md
@@ -1,10 +1,10 @@
-#Single Player Commands Pocket Edition BETA
+# Single Player Commands Pocket Edition BETA
 
-###This is a script that adds commands to Minecraft Pocket Edition
+### This is a script that adds commands to Minecraft Pocket Edition
 
-###Currently being re-written
+### Currently being re-written
 
-##Current commands
+## Current commands
 | Command | Description | Usage | Example |
 | :---: | :--- | :---: | :---: |
 | /ascend | Ascends the player to the platform above | /ascend | /ascend |
@@ -30,9 +30,9 @@
 | /time | Sets the in-game time | /time `<day/night/sunrise/sunset/midday/midnight>` | /time sunrise |
 | /tp | Teleports the player to the specified coordinates | /tp `<X>` `<Y>` `<Z>` | /tp 43 64 78 |
 | /unbind | Unbinds all commands from the GUI button | /unbind | /unbind |
-###Key
-#####lowercase = type exact word
-#####UPPERCASE = typed word can vary
-#####< > = required parameter
-#####[ ] = optional parameter
-####Do not include the [ ] or < > in your commands
+### Key
+##### lowercase = type exact word
+##### UPPERCASE = typed word can vary
+##### < > = required parameter
+##### [ ] = optional parameter
+#### Do not include the [ ] or < > in your commands

--- a/SPC/old/README.md
+++ b/SPC/old/README.md
@@ -1,8 +1,8 @@
-#Single Player Commands v14
+# Single Player Commands v14
 
-###This is a script that adds commands to Minecraft Pocket Edition
+### This is a script that adds commands to Minecraft Pocket Edition
 
-###Commands:
+### Commands:
 | Command | Parameters | Description | Example |
 | :---: | :---: | :--- | :---: |
 | /help | `<COMMAND>` | Shows help about a specific command | /help explode |
@@ -51,8 +51,8 @@
 | /warp | `<on>` | Gives you a slimeball, a diamond hoe, a gold hoe, and a few blocks of diamond, gold, iron, and lapis, and activates Warp Panels | |
 | /warp | `<off>` | Deactivates the Warp Panels | |
 
-#####lowercase = exact word to type, CAPS = different words can be entered
-###Changelog:
+##### lowercase = exact word to type, CAPS = different words can be entered
+### Changelog:
 
 ```
 Single Player Commands v1:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
